### PR TITLE
Bugfix beim bin Verzeichnis + Installationshinweise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ bower_components
 ### Eclipse ###
 
 .metadata
-bin/
 tmp/
 *.tmp
 *.bak

--- a/Node-Express-Demo/bin/www
+++ b/Node-Express-Demo/bin/www
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var app = require('../app');
+var debug = require('debug')('taggeo:server');
+var http = require('http');
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+var server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+  var port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+/**
+ * Event listener for HTTP server "error" event.
+ */
+
+function onError(error) {
+  if (error.syscall !== 'listen') {
+    throw error;
+  }
+
+  var bind = typeof port === 'string'
+    ? 'Pipe ' + port
+    : 'Port ' + port;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case 'EACCES':
+      console.error(bind + ' requires elevated privileges');
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      console.error(bind + ' is already in use');
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+  var addr = server.address();
+  var bind = typeof addr === 'string'
+    ? 'pipe ' + addr
+    : 'port ' + addr.port;
+  debug('Listening on ' + bind);
+}

--- a/Node-Express-Demo/package.json
+++ b/Node-Express-Demo/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "VS1-Node-Express-Demo",
-  "version": "0.0.0",
+  "name": "Node-Express-Demo",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # HsKA Web Engineering Lab (weblab)
 Collection of lab examples and exercise projects
-* Node-Express-Demo: simple Express web app from the lecture
+* Node-Express-Demo: A simple Express.js web app from the lecture
+
+
+## Install
+
+    cd Node-Express-Demo
+    npm install
+
+## Run
+
+    cd Node-Express-Demo
+    npm start


### PR DESCRIPTION
Sehr geehrter Prof. Zirpins,

beim Testen der Demo-Webapp ist mir aufgefallen, dass das bin Verzeichnis von Express.js wegen der gitignore Datrei nicht vorhanden ist und das Projekt nicht gestartet werden kann.
Ich habe das Verzeichnis bei mir samt www Datei angelegt und die README Datei um Installationshinweise ergänzt.
Detrails können Sie den Commit-Messages entnehmen.

MfG,
  Johannes Heinz